### PR TITLE
Fix: fix gradlew version and replace all vers.

### DIFF
--- a/catalogue/gradle/wrapper/gradle-wrapper.properties
+++ b/catalogue/gradle/wrapper/gradle-wrapper.properties
@@ -20,4 +20,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip


### PR DESCRIPTION
Due to a manual rebase mistake the gradlew version in one file is still
2.4 and there is a gradle-3.3-all instead gradle-3.3-bin version. Gradle
suggest to use the bin (without the documentation and source code)